### PR TITLE
Fix SmartPunctExtension use statement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Extensions can be added to any new `Environment`:
 ``` php
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
-new League\CommonMark\Extras\SmartPunct\SmartPunctExtension;
+use League\CommonMark\Extras\SmartPunct\SmartPunctExtension;
 
 // Obtain a pre-configured Environment with all the CommonMark parsers/renderers ready-to-go
 $environment = Environment::createCommonMarkEnvironment();


### PR DESCRIPTION
The `use` statement for `SmartPunctExtension` had `new` rather than
`use`.

Just a minor fix to the example in the `README.md` file.