### PR TITLE
Deprecate extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All Notable changes to `commonmark-extras` will be documented in this file
 
 ## [Unreleased][unreleased]
 
+## [1.2.0] - 2020-04-04
+
+### Deprecated
+
+**This extension has been deprecated**.  All of its functionality now exists in league/commonmark 1.3+ as `GithubFlavoredMarkdownExtension`.
+
 ## [1.1.0] - 2019-07-13
 
 ### Added
@@ -102,7 +108,8 @@ No changes have been introduced since 1.0.0-beta2.
 ### Changed
  - Minor refactoring to SmartPunct's `QuoteParser` to reduce complexity
 
-[unreleased]: https://github.com/thephpleague/commonmark-extras/compare/1.1.0...HEAD
+[unreleased]: https://github.com/thephpleague/commonmark-extras/compare/1.2.0...HEAD
+[1.2.0]: https://github.com/thephpleague/commonmark-extras/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/thephpleague/commonmark-extras/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/thephpleague/commonmark-extras/compare/1.0.0-beta2...1.0.0
 [1.0.0-beta2]: https://github.com/thephpleague/commonmark-extras/compare/1.0.0-beta1...1.0.0-beta2

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 [![Quality Score][ico-code-quality]][link-code-quality]
 [![Total Downloads][ico-downloads]][link-downloads]
 
+## DEPRECATED
+
+**This extension has been deprecated**.  All of its functionality now exists in [`league/commonmark`][link-league-commonmark] 1.3+.  You can either register the various extensions individually or use the `GithubFlavoredMarkdownExtension` to get full GFM functionality, so you should upgrade to that version of `league/commonmark` and use that instead of this one.
+
+## Overview
+
 **league/commonmark-extras** is a collection of useful GFM extensions and utilities
 for the [league/commonmark][link-league-commonmark] project.
 

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,7 @@
     ],
     "require": {
         "php" : "^7.1",
-        "league/commonmark": "^1.0",
-        "league/commonmark-ext-autolink": "^1.0",
-        "league/commonmark-ext-smartpunct": "^1.0",
-        "league/commonmark-ext-strikethrough": "^1.0",
-        "league/commonmark-ext-table": "^2.0",
-        "league/commonmark-ext-task-list": "^1.0"
+        "league/commonmark": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit" : "^7.5"
@@ -40,7 +35,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2-dev"
+            "dev-master": "1.3-dev"
         }
-    }
+    },
+    "abandoned": "league/commonmark"
 }

--- a/src/CommonMarkExtrasExtension.php
+++ b/src/CommonMarkExtrasExtension.php
@@ -12,15 +12,24 @@
 namespace League\CommonMark\Extras;
 
 use League\CommonMark\ConfigurableEnvironmentInterface;
-use League\CommonMark\Ext\Autolink\AutolinkExtension;
-use League\CommonMark\Ext\SmartPunct\SmartPunctExtension;
-use League\CommonMark\Ext\Strikethrough\StrikethroughExtension;
-use League\CommonMark\Ext\Table\TableExtension;
-use League\CommonMark\Ext\TaskList\TaskListExtension;
+use League\CommonMark\Extension\Autolink\AutolinkExtension;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\Extension\SmartPunct\SmartPunctExtension;
+use League\CommonMark\Extension\Strikethrough\StrikethroughExtension;
+use League\CommonMark\Extension\Table\TableExtension;
+use League\CommonMark\Extension\TaskList\TaskListExtension;
 use League\CommonMark\Extension\ExtensionInterface;
 
+/**
+ * @deprecated The league/commonmark-extras extension is now deprecated. All functionality has been moved into league/commonmark 1.3+, so use that instead.
+ */
 final class CommonMarkExtrasExtension implements ExtensionInterface
 {
+    public function __construct()
+    {
+        @trigger_error(sprintf('league/commonmark-extras is deprecated; use individual extensions or %s from league/commonmark 1.3+ instead', GithubFlavoredMarkdownExtension::class), E_USER_DEPRECATED);
+    }
+
     public function register(ConfigurableEnvironmentInterface $environment)
     {
         $environment->addExtension(new AutolinkExtension());

--- a/tests/CommonMarkExtrasExtensionTest.php
+++ b/tests/CommonMarkExtrasExtensionTest.php
@@ -49,10 +49,8 @@ EOT;
 </table>
 <p>Don’t forget to:</p>
 <ul>
-<li>
-<input disabled="" type="checkbox" /> Star this repository</li>
-<li>
-<input disabled="" type="checkbox" checked="" /> Keep on being awesome!</li>
+<li><input disabled="" type="checkbox"> Star this repository</li>
+<li><input checked="" disabled="" type="checkbox"> Keep on being awesome!</li>
 </ul>
 
 EOT;


### PR DESCRIPTION
Implements #20

**This extension is being deprecated**.  All of its functionality now exists in league/commonmark 1.3+ as `GithubFlavoredMarkdownExtension`.

